### PR TITLE
Update PHP version in README.md for Vercel deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Add the following snippet to `build.sh` file to install PHP, Composer, and run t
 
 # Install PHP & WGET
 yum install -y amazon-linux-extras
-amazon-linux-extras enable php7.4
+amazon-linux-extras enable php8.2
 yum clean metadata
 yum install php php-{common,curl,mbstring,gd,gettext,bcmath,json,xml,fpm,intl,zip,imap}
 yum install wget


### PR DESCRIPTION
The latest version of amazon-linux-extras available on Vercel contains PHP 8.2.